### PR TITLE
Numdifftools v0.9.42

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD-3-Clause license
-Copyright (c) 2015-2022, conda-forge contributors
+Copyright (c) 2015-2025, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,8 @@
 {% set name = "numdifftools" %}
-{% set version = "0.9.41" %}
-{% set sha256 = "4ef705cd3c06211b3a4e9fd05ad622be916dcfda40732f0128805a2c4be389b4" %}
+{% set version = "0.9.42" %}
+{% set sha256 = "866675171f293c4bf2f1e1c5bf9b88a07d5396903e3b3e7fcc3879e2a01cfbc1" %}
+{% set python_min = "3.10" %}
+
 
 package:
   name: {{ name|lower }}
@@ -12,30 +14,38 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  # Reset build number to 0 for a new version upload
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   noarch: python
 
 requirements:
   host:
     - python {{ python_min }}
-    - setuptools
+    - pdm-backend
     - pip
-    - pytest-runner  # in setup_requires for some reason
+    - setuptools
   run:
     - python >={{ python_min }}
-    - numpy >=1.9
-    - scipy >=0.8
-    - algopy >=0.4
-    - statsmodels >=0.6
+    - numpy >=1.21.2
+    - scipy >=1.7.3
 
 test:
   requires:
     - python {{ python_min }}
+    - pip
+    - pytest
+    - pytest-cov
+    - numpy
+    - scipy
+    - algopy >=0.4
+    - statsmodels >=0.6
+    - matplotlib >=3.8.0
   imports:
     - numdifftools
     - numdifftools.tests
   commands:
+    - pip check
     - python -m numdifftools.tests.test_multicomplex
 
 about:
@@ -44,7 +54,7 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
-  doc_url: http://numdifftools.readthedocs.io/en/latest/
+  doc_url: https://numdifftools.readthedocs.io/en/latest/
   dev_url: https://github.com/pbrod/numdifftools/
 
 extra:


### PR DESCRIPTION
@ conda-forge-admin, please rerender

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

### Summary of Changes

1. Version and Build:
     {% set version = "0.9.42" %}: Updated the version.
     build: number: 2: (version unchanged).
2. Dependencies (requirements):

    python >=3.10 in both host and run sections, reflecting the requires-python in pyproject.toml.
    numpy and scipy versions updated to match the constraints in pyproject.toml.
    Added pdm-backend to host requirements to enable the PDM build system.
    The older dependencies (algopy, statsmodels) were removed from run since they are not in the core [project].dependencies of pyproject.toml.

3. Test Dependencies (test.requires):

     Added pytest and pytest-cov to align with the testing setup in pyproject.toml (addopts section).

     Added back algopy, statsmodels, and matplotlib here, as they are used in the test environment or optional features.

4. Test Commands (test.commands):

    Replaced the specific test script call with the general pytest command, which is the preferred execution method shown in    pyproject.toml.

5. Metadata:

Updated doc_url to the standard HTTPS link from pyproject.toml.